### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # MultiObjectTrackingBasedOnColor
 [![ghit.me](https://ghit.me/badge.svg?repo=akaifi/MultiObjectTrackingBasedOnColor)](https://ghit.me/repo/akaifi/MultiObjectTrackingBasedOnColor)
-###Track multiple objects based on their color using OpenCV
+### Track multiple objects based on their color using OpenCV
 ---
 
-####In order to run the application, you need to do the follwing steps:
+#### In order to run the application, you need to do the follwing steps:
 
 1 - Proper installation of OpenCV V2.4.9
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/akaifi/multiobjecttrackingbasedoncolor/6)
<!-- Reviewable:end -->
